### PR TITLE
Solve typo in sublanguageid param key

### DIFF
--- a/opensrt.js
+++ b/opensrt.js
@@ -33,7 +33,7 @@ exports.searchEpisode = function(data, cb) {
 
 function searchEpisode(data, cb) {
 	var opts = {};
-	opts.sublanaguageid = "all";
+	opts.sublanguageid = "all";
 	if(!data.filename) {
 		opts.imdbid = data.imdbid.replace("tt", "");
 		opts.season = data.season;


### PR DESCRIPTION
`sublanaguageid` changed to `sublanguageid`.

According to http://trac.opensubtitles.org/projects/opensubtitles/wiki/XMLRPC#SearchSubtitles.
